### PR TITLE
Update max version to be well in the future

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,7 +11,7 @@ var Metrics = [
 var Channels = ["beta" ];
 var CurrentResults = undefined;
 
-const maxVersion = 54;
+const maxVersion = 100;
 const minVersion = 44;
 function collectEvolution(channel, version, metric, cb) {
   console.log("Collecting " + metric + ":" + channel + ":" + version);


### PR DESCRIPTION
@potch: this is why we were getting the apparent drop in HTTPS usage. We were only seeing beta 54 and below, and those apparently are lamer. Probably we should eventually remove max, not quite sure why I had it, but htis will fix our problems for quite some time. I'll let you merge this in b/c not quite sure of the heroku mechanics.